### PR TITLE
Set up Notification Bot

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -20,6 +20,27 @@ class Admin {
 	private $plugin;
 
 	/**
+	 * Slack Username
+	 *
+	 * @var string
+	 */
+    private $username;
+
+	/**
+	 * Slack Channel
+	 *
+	 * @var string
+	 */
+    private $channel;
+
+	/**
+	 * Slack WebHook
+	 *
+	 * @var string
+	 */
+    private $webhook;
+
+	/**
 	 * Instantiate class
 	 *
 	 * @return void

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -105,4 +105,31 @@ class Admin {
         $this->channel = carbon_get_theme_option( 'crb_slack_channel' );
         $this->webhook = carbon_get_theme_option( 'crb_slack_webhook' );
     }
+
+	/**
+	 * Return private username
+	 *
+	 * @return string
+	 */
+	public function get_username() {
+		return $this->username;
+	}
+
+	/**
+	 * Return private channel
+	 *
+	 * @return string
+	 */
+	public function get_channel() {
+		return $this->channel;
+	}
+
+	/**
+	 * Return private webhook
+	 *
+	 * @return string
+	 */
+	public function get_webhook() {
+		return $this->webhook;
+	}
 }

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -49,6 +49,7 @@ class Admin {
 		$this->plugin = $plugin;
 		add_action( 'after_setup_theme', [ $this, 'init' ] );
         add_action( 'carbon_fields_register_fields', [ $this, 'load_fields' ] );
+        add_action( 'carbon_fields_register_fields', [ $this, 'set_fields' ] );
 	}
 
 	/**
@@ -92,5 +93,16 @@ class Admin {
 			Field::make( 'text', 'crb_slack_webhook', 'Slack WebHook' )
 			->help_text( 'e.g. https://hooks.slack.com/services/xxxxxx' )
 		) );
+    }
+
+	/**
+	 * Retrieve Carbon Field values and set private variables
+	 *
+	 * @return void
+	 */
+    public function set_fields() {
+        $this->username = carbon_get_theme_option( 'crb_slack_username' );
+        $this->channel = carbon_get_theme_option( 'crb_slack_channel' );
+        $this->webhook = carbon_get_theme_option( 'crb_slack_webhook' );
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,8 @@
 
 namespace SlackBot;
 
+use Maknz\Slack\Client;
+
 /**
  * WordPress plugin interface.
  */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -35,6 +35,7 @@ class Plugin {
 	 */
 	public function __construct() {
 		$this->admin = new Admin( $this );
+        add_action( 'publish_post', [ $this, 'notify_my_slack' ], 10, 2);
 	}
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -37,6 +37,23 @@ class Plugin {
 		$this->admin = new Admin( $this );
 	}
 
+    /**
+     * Notify Slack
+     *
+     * @return void
+     */
+    public function notify_my_slack( $post_id, $post ) {
+        $slack_hook = $this->admin->webhook;
+        $slack_message = 'New Post alert | %3$s: *%2$s* - %1$s';
+        $slack_message = sprintf( $slack_message, get_permalink( $post_id ), $post->post_title, $post->post_date );
+        $settings = [
+            'username' => $this->admin->username,
+            'channel'  => $this->admin->channel,
+        ];
+        $client = new Client( $slack_hook, $settings );
+        $client->send( $slack_message );
+    }
+
 	/**
 	 * Plugin Entry point based on Singleton
 	 *

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,12 +44,12 @@ class Plugin {
      * @return void
      */
     public function notify_my_slack( $post_id, $post ) {
-        $slack_hook = $this->admin->webhook;
+        $slack_hook = $this->admin->get_webhook();
         $slack_message = 'New Post alert | %3$s: *%2$s* - %1$s';
         $slack_message = sprintf( $slack_message, get_permalink( $post_id ), $post->post_title, $post->post_date );
         $settings = [
-            'username' => $this->admin->username,
-            'channel'  => $this->admin->channel,
+            'username' => $this->admin->get_username(),
+            'channel'  => $this->admin->get_channel(),
         ];
         $client = new Client( $slack_hook, $settings );
         $client->send( $slack_message );


### PR DESCRIPTION
Retrieves Carbon Field values and passes them on to Plugin Class.
Sets up the Notification feature by hooking PHP/Slack's client call to WP publish_post Action Hook. 